### PR TITLE
First draft of SClang ANTLR grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+grammar/.antlr/
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Sparkler
+
+A SuperCollider parser library.
+
+Sparkler uses ANTLR to generate SuperCollider parsers in C++, Python,
+and JavaScript. We also plan to add unofficial parser generator support
+to ANTLR to generate a SuperCollider parser in SuperCollider.
+
+# Using the Generated Parsers
+
+# Rebuilding The Parser Libraries
+
+## macOS
+
+`brew install antlr`
+
+To get vscode extension working, install JRE from https://www.java.com/en/download/

--- a/README.md
+++ b/README.md
@@ -8,10 +8,17 @@ to ANTLR to generate a SuperCollider parser in SuperCollider.
 
 # Using the Generated Parsers
 
+TBD
+
 # Rebuilding The Parser Libraries
+
+TBD
 
 ## macOS
 
+Homebrew includes ANTLR4:
+
 `brew install antlr`
 
-To get vscode extension working, install JRE from https://www.java.com/en/download/
+To get the [VScode ANTLR](https://github.com/mike-lischke/vscode-antlr4)
+extension working, install the [JRE](https://www.java.com/en/download/).

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -62,7 +62,7 @@ PIPE : '|' ;
 
 PLUS : '+' ;
 
-PRIMITIVE : '_' [a-zA-Z0-9_]* ;
+PRIMITIVE : '_' [a-zA-Z0-9_]+ ;
 
 READ_WRITE : '<>' ;
 

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -1,0 +1,92 @@
+lexer grammar SCLexer;
+
+ARG : 'arg' ;
+
+ARROW_LEFT : '<-' ;
+
+ASTERISK : '*' ;
+
+BINOP : ('!' | '@' | '%' | '&' | '*' | '-' | '+' | '=' | '|' | '<' | '>' | '?' | '/')+ ;
+
+CARET : '^' ;
+
+CLASSNAME : [A-Z] [a-zA-Z0-9_]* ;
+
+CLASSVAR : 'classvar' ;
+
+COLON : ':' ;
+
+COMMA : ',' ;
+
+COMMENT_LINE : '//' .*? '\n' -> channel(2) ;
+COMMENT_BLOCK : '/*' -> channel(2), pushMode(INSIDE_BLOCK) ;
+
+CONST : 'const' ;
+
+CURLY_OPEN : '{' ;
+CURLY_CLOSE : '}' ;
+
+DOT : '.' ;
+DOT_DOT : '..' ;
+
+ELLIPSES : '...' ;
+
+EQUALS : '=' ;
+
+FLOAT : [-]? [0-9]+ '.' [0-9]+ ;
+FLOAT_RADIX : [-]? [1-9] [0-9]* 'r' [a-zA-Z0-9]+ '.' [A-Z0-9]+ ;
+FLOAT_SCI : [-]? [0-9]+ ('.' [0-9]+)? 'e' ('-' | '+')? [0-9]+ ;
+
+GREATER_THAN : '>' ;
+
+HASH : '#' ;
+
+INT : [-]? [1-9] [0-9]* ;
+INT_HEX : [-]? '0x' [0-9a-f]* ;
+INT_RADIX : [-]? [1-9] [0-9]* 'r' [a-zA-Z0-9]+ ;
+
+KEYWORD : [a-z] [a-zA-Z0-9_]* ':' ;
+
+LESS_THAN : '<' ;
+
+MINUS : '-' ;
+
+NAME : [a-z] [a-zA-Z0-9_]* ;
+
+PAREN_OPEN : '(' ;
+PAREN_CLOSE : ')' ;
+
+PI : 'pi' ;
+
+PIPE : '|' ;
+
+PLUS : '+' ;
+
+PRIMITIVE : '_' [a-zA-Z0-9_]* ;
+
+READ_WRITE : '<>' ;
+
+SEMICOLON : ';' ;
+
+STRING : '"' (.|'\\"')*? '"' ;
+
+SQUARE_OPEN : '[' ;
+SQUARE_CLOSE : ']' ;
+
+SYMBOL_QUOTE : '\'' (.|'\\\'')*? ;
+SYMBOL_SLASH : '\\' [a-zA-Z0-9_]* ;
+
+TILDE : '~' ;
+
+UNDERSCORE : '_' ;
+
+VAR : 'var' ;
+
+WHITESPACE : [ \t\r\n]+ -> channel(HIDDEN) ;
+
+WHILE : 'while' ;
+
+mode INSIDE_BLOCK;
+END_BLOCK : '*/' -> channel(2), popMode ;
+IGNORE : . -> more ;
+NEST_BLOCK : '/*' -> channel(2), pushMode(INSIDE_BLOCK) ;

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -34,8 +34,12 @@ ELLIPSES : '...' ;
 EQUALS : '=' ;
 
 FLOAT : [-]? [0-9]+ '.' [0-9]+ ;
+FLOAT_FLAT : [0-9]+ 'b'+ ;
+FLOAT_FLAT_CENTS : [0-9]+ 'b' [0-9]+ ;
 FLOAT_RADIX : [-]? [1-9] [0-9]* 'r' [a-zA-Z0-9]+ '.' [A-Z0-9]+ ;
 FLOAT_SCI : [-]? [0-9]+ ('.' [0-9]+)? 'e' ('-' | '+')? [0-9]+ ;
+FLOAT_SHARP : [0-9]+ 's'+ ;
+FLOAT_SHARP_CENTS : [0-9]+ 's' [0-9]+ ;
 
 GREATER_THAN : '>' ;
 

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -45,6 +45,8 @@ GREATER_THAN : '>' ;
 
 HASH : '#' ;
 
+INF : 'inf' ;
+
 INT : [-]? [1-9] [0-9]* ;
 INT_HEX : [-]? '0x' [0-9a-f]* ;
 INT_RADIX : [-]? [1-9] [0-9]* 'r' [a-zA-Z0-9]+ ;

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -4,9 +4,7 @@ options {
   tokenVocab=SCLexer;
 }
 
-root : topLevelStatement* EOF
-     | /* empty */
-     ;
+root : topLevelStatement* EOF ;
 
 topLevelStatement : classDef
                   | classExtension
@@ -139,32 +137,6 @@ expr1 : literal
       | indexSeries
       ;
 
-block : HASH? CURLY_OPEN argDecls? varDecls? body? CURLY_CLOSE ;
-
-body : return?
-     | exprSeq return?
-     ;
-
-return : CARET expr SEMICOLON? ;
-
-exprSeq : expr (SEMICOLON expr)* SEMICOLON? ;
-
-varDecls    : (VAR varDefList SEMICOLON)*? ;
-
-listComp : CURLY_OPEN COLON exprSeq COMMA qualifiers CURLY_CLOSE
-         | CURLY_OPEN SEMICOLON exprSeq COMMA qualifiers CURLY_CLOSE
-         ;
-
-qualifiers : qualifier (COMMA qualifier)* ;
-
-qualifier : NAME ARROW_LEFT exprSeq
-          | NAME NAME ARROW_LEFT exprSeq
-          | exprSeq
-          | VAR NAME EQUALS exprSeq
-          | COLON COLON exprSeq
-          | COLON WHILE exprSeq
-          ;
-
 message : NAME block+
         | PAREN_OPEN binopKey PAREN_CLOSE block+
         | NAME PAREN_OPEN PAREN_CLOSE block+
@@ -190,6 +162,38 @@ message : NAME block+
         | expr DOT NAME block*
         ;
 
+indexSeries : expr1 SQUARE_OPEN argList DOT_DOT exprSeq? SQUARE_CLOSE
+            | expr1 SQUARE_OPEN DOT_DOT exprSeq SQUARE_CLOSE
+            ;
+
+indexSeriesAssign : indexSeries EQUALS expr;
+
+block : HASH? CURLY_OPEN argDecls? varDecls? body? CURLY_CLOSE ;
+
+body : return
+     | exprSeq return?
+     ;
+
+return : CARET expr SEMICOLON? ;
+
+exprSeq : expr (SEMICOLON expr)* SEMICOLON? ;
+
+varDecls : (VAR varDefList SEMICOLON)+ ;
+
+listComp : CURLY_OPEN COLON exprSeq COMMA qualifiers CURLY_CLOSE
+         | CURLY_OPEN SEMICOLON exprSeq COMMA qualifiers CURLY_CLOSE
+         ;
+
+qualifiers : qualifier (COMMA qualifier)* ;
+
+qualifier : NAME ARROW_LEFT exprSeq
+          | NAME NAME ARROW_LEFT exprSeq
+          | exprSeq
+          | VAR NAME EQUALS exprSeq
+          | COLON COLON exprSeq
+          | COLON WHILE exprSeq
+          ;
+
 binopKey : BINOP
          | KEYWORD
          ;
@@ -211,12 +215,6 @@ arrayElem : (exprSeq COLON)? exprSeq
 numericSeries : exprSeq (COMMA exprSeq)? DOT_DOT exprSeq?
               | DOT_DOT exprSeq
               ;
-
-indexSeries : expr1 SQUARE_OPEN argList DOT_DOT exprSeq? SQUARE_CLOSE
-            | expr1 SQUARE_OPEN DOT_DOT exprSeq SQUARE_CLOSE
-            ;
-
-indexSeriesAssign : indexSeries EQUALS expr;
 
 adverb : DOT NAME
        | DOT integer

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -117,7 +117,7 @@ expr : expr1
      | expr DOT NAME EQUALS expr
      | NAME PAREN_OPEN argList keyArgList? PAREN_CLOSE EQUALS expr
      | HASH multiAssignVars EQUALS expr
-        // problem is that these are msgsends, which are expr1s
+        // These are msgsends, which are expr1s
         | expr DOT PAREN_OPEN PAREN_CLOSE block*
         | expr DOT PAREN_OPEN keyArgList? COMMA? PAREN_CLOSE block*
         | expr DOT NAME PAREN_OPEN keyArgList COMMA? PAREN_CLOSE block*

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -61,6 +61,7 @@ floatingPoint : floatLiteral
 floatLiteral : FLOAT
              | FLOAT_RADIX
              | FLOAT_SCI
+             | INF
              ;
 
 accidental : FLOAT_FLAT

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -12,7 +12,7 @@ topLevelStatement : classDef
                   ;
 
 classDef : CLASSNAME superclass? CURLY_OPEN classVarDecl* method* CURLY_CLOSE
-         | CLASSNAME SQUARE_OPEN NAME? SQUARE_CLOSE superclass? CURLY_OPEN classVarDecl* method* CURLY_CLOSE
+         | CLASSNAME SQUARE_OPEN name? SQUARE_CLOSE superclass? CURLY_OPEN classVarDecl* method* CURLY_CLOSE
          ;
 
 superclass : COLON CLASSNAME ;
@@ -24,12 +24,16 @@ classVarDecl : CLASSVAR rwSlotDefList SEMICOLON
 
 rwSlotDefList : rwSlotDef (COMMA rwSlotDef)* ;
 
-rwSlotDef : rwSpec? NAME (EQUALS literal)? ;
+rwSlotDef : rwSpec? name (EQUALS literal)? ;
 
 rwSpec : LESS_THAN
        | GREATER_THAN
        | READ_WRITE
        ;
+
+name : NAME
+     | WHILE
+     ;
 
 literal : coreLiteral
         | listLiteral
@@ -51,12 +55,19 @@ floatingPoint : floatLiteral
               | integer PI
               | PI
               | MINUS PI
+              | accidental
               ;
 
 floatLiteral : FLOAT
              | FLOAT_RADIX
              | FLOAT_SCI
              ;
+
+accidental : FLOAT_FLAT
+           | FLOAT_FLAT_CENTS
+           | FLOAT_SHARP
+           | FLOAT_SHARP_CENTS
+           ;
 
 strings : STRING+ ;
 
@@ -67,7 +78,7 @@ symbol : SYMBOL_QUOTE
 listLiteral : coreLiteral
             | innerListLiteral
             | innerDictLiteral
-            | NAME
+            | name
             ;
 
 innerListLiteral : SQUARE_OPEN listLiterals? SQUARE_CLOSE
@@ -86,57 +97,57 @@ dictLiteral : listLiteral COLON listLiteral
 
 constDefList : rSlotDef (COMMA rSlotDef)* ;
 
-rSlotDef   : LESS_THAN? NAME
-           | LESS_THAN? NAME EQUALS literal
+rSlotDef   : LESS_THAN? name
+           | LESS_THAN? name EQUALS literal
            ;
 
 method : ASTERISK? methodName CURLY_OPEN argDecls? varDecls? primitive? body? CURLY_CLOSE ;
 
-methodName : NAME
+methodName : name
            | BINOP
            ;
 
 argDecls : ARG varDefList SEMICOLON
-         | ARG varDefList? ELLIPSES NAME SEMICOLON
+         | ARG varDefList? ELLIPSES name SEMICOLON
          | PIPE pipeDefList PIPE
-         | PIPE pipeDefList? ELLIPSES NAME PIPE
+         | PIPE pipeDefList? ELLIPSES name PIPE
          ;
 
 varDefList : varDef (COMMA varDef)* ;
 
-varDef : NAME
-       | NAME EQUALS expr
-       | NAME PAREN_OPEN exprSeq PAREN_CLOSE
+varDef : name
+       | name EQUALS expr
+       | name PAREN_OPEN exprSeq PAREN_CLOSE
        ;
 
 expr : expr1
      | CLASSNAME
      | expr binopKey adverb? expr
-     | NAME EQUALS expr
-     | TILDE  NAME EQUALS expr
-     | expr DOT NAME EQUALS expr
-     | NAME PAREN_OPEN argList keyArgList? PAREN_CLOSE EQUALS expr
+     | name EQUALS expr
+     | TILDE  name EQUALS expr
+     | expr DOT name EQUALS expr
+     | name PAREN_OPEN argList keyArgList? PAREN_CLOSE EQUALS expr
      | HASH multiAssignVars EQUALS expr
         // These are msgsends, which are expr1s
         | expr DOT PAREN_OPEN PAREN_CLOSE block*
         | expr DOT PAREN_OPEN keyArgList? COMMA? PAREN_CLOSE block*
-        | expr DOT NAME PAREN_OPEN keyArgList COMMA? PAREN_CLOSE block*
+        | expr DOT name PAREN_OPEN keyArgList COMMA? PAREN_CLOSE block*
         | expr DOT PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
         | expr DOT PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
-        | expr DOT NAME PAREN_OPEN PAREN_CLOSE block*
-        | expr DOT NAME PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
-        | expr DOT NAME PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
-        | expr DOT NAME block*
+        | expr DOT name PAREN_OPEN PAREN_CLOSE block*
+        | expr DOT name PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
+        | expr DOT name PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
+        | expr DOT name block*
      ;
 
 expr1 : literal
       | block
       | listComp
-      | NAME
+      | name
       | UNDERSCORE
       | message
       | PAREN_OPEN exprSeq PAREN_CLOSE
-      | TILDE NAME
+      | TILDE name
       | SQUARE_OPEN arrayElems SQUARE_CLOSE
       | PAREN_OPEN numericSeries PAREN_CLOSE
       | PAREN_OPEN COLON numericSeries PAREN_CLOSE
@@ -151,13 +162,13 @@ expr1 : literal
       | expr1 SQUARE_OPEN DOT_DOT exprSeq SQUARE_CLOSE EQUALS expr
       ;
 
-message : NAME block+
+message : name block+
         | PAREN_OPEN binopKey PAREN_CLOSE block+
-        | NAME PAREN_OPEN PAREN_CLOSE block+
-        | NAME PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
+        | name PAREN_OPEN PAREN_CLOSE block+
+        | name PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
         | PAREN_OPEN binopKey PAREN_CLOSE PAREN_OPEN PAREN_CLOSE block+
         | PAREN_OPEN binopKey PAREN_CLOSE PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
-        | NAME PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
+        | name PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
         | PAREN_OPEN binopKey PAREN_CLOSE PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
         | CLASSNAME SQUARE_OPEN arrayElems? SQUARE_CLOSE
         | CLASSNAME block+
@@ -185,10 +196,10 @@ listComp : CURLY_OPEN COLON exprSeq COMMA qualifiers CURLY_CLOSE
 
 qualifiers : qualifier (COMMA qualifier)* ;
 
-qualifier : NAME ARROW_LEFT exprSeq
-          | NAME NAME ARROW_LEFT exprSeq
+qualifier : name ARROW_LEFT exprSeq
+          | name name ARROW_LEFT exprSeq
           | exprSeq
-          | VAR NAME EQUALS exprSeq
+          | VAR name EQUALS exprSeq
           | COLON COLON exprSeq
           | COLON WHILE exprSeq
           ;
@@ -215,17 +226,17 @@ numericSeries : exprSeq (COMMA exprSeq)? DOT_DOT exprSeq?
               | DOT_DOT exprSeq
               ;
 
-adverb : DOT NAME
+adverb : DOT name
        | DOT integer
        | DOT PAREN_OPEN exprSeq PAREN_CLOSE
        ;
 
-multiAssignVars : NAME (COMMA NAME)* (ELLIPSES NAME)? ;
+multiAssignVars : name (COMMA name)* (ELLIPSES name)? ;
 
 pipeDefList : pipeDef (COMMA pipeDef)* ;
 
-pipeDef : NAME EQUALS? literal?
-        | NAME EQUALS? PAREN_OPEN exprSeq PAREN_CLOSE
+pipeDef : name EQUALS? literal?
+        | name EQUALS? PAREN_OPEN exprSeq PAREN_CLOSE
         ;
 
 primitive : PRIMITIVE SEMICOLON? ;

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -1,0 +1,242 @@
+parser grammar SCParser;
+
+options {
+  tokenVocab=SCLexer;
+}
+
+root : topLevelStatement* EOF
+     | /* empty */
+     ;
+
+topLevelStatement : classDef
+                  | classExtension
+                  | interpreterCode
+                  ;
+
+classDef : CLASSNAME superclass? CURLY_OPEN classVarDecl* method* CURLY_CLOSE
+         | CLASSNAME SQUARE_OPEN NAME? SQUARE_CLOSE superclass? CURLY_OPEN classVarDecl* method* CURLY_CLOSE
+         ;
+
+superclass : COLON CLASSNAME ;
+
+classVarDecl : CLASSVAR rwSlotDefList SEMICOLON
+             | VAR rwSlotDefList SEMICOLON
+             | CONST constDefList SEMICOLON
+             ;
+
+rwSlotDefList : rwSlotDef (COMMA rwSlotDef)* ;
+
+rwSlotDef : rwSpec? NAME (EQUALS literal)? ;
+
+rwSpec : LESS_THAN
+       | GREATER_THAN
+       | READ_WRITE
+       ;
+
+literal : coreLiteral
+        | listLiteral
+        ;
+
+coreLiteral : integer
+            | float
+            | strings
+            | symbol
+            ;
+
+integer : INT
+        | INT_HEX
+        | INT_RADIX
+        ;
+
+float : floatLiteral
+      | floatLiteral PI
+      | integer PI
+      | PI
+      | MINUS PI
+      ;
+
+floatLiteral : FLOAT
+             | FLOAT_RADIX
+             | FLOAT_SCI
+             ;
+
+strings : STRING+ ;
+
+symbol : SYMBOL_QUOTE
+       | SYMBOL_SLASH
+       ;
+
+listLiteral : coreLiteral
+            | innerListLiteral
+            | innerDictLiteral
+            | NAME
+            ;
+
+innerListLiteral : SQUARE_OPEN listLiterals? SQUARE_CLOSE
+                 | CLASSNAME SQUARE_OPEN listLiterals? SQUARE_CLOSE
+                 ;
+
+listLiterals : listLiteral (COMMA listLiteral)* ;
+
+innerDictLiteral : PAREN_OPEN dictLiterals? PAREN_CLOSE ;
+
+dictLiterals : dictLiteral (COMMA dictLiteral)* ;
+
+dictLiteral : listLiteral COLON listLiteral
+            | KEYWORD listLiteral
+            ;
+
+constDefList : rSlotDef (COMMA rSlotDef)* ;
+
+rSlotDef   : LESS_THAN? NAME
+           | LESS_THAN? NAME EQUALS literal
+           ;
+
+method : ASTERISK? methodName CURLY_OPEN argDecls? varDecls? primitive? body? CURLY_CLOSE ;
+
+methodName : NAME
+           | BINOP
+           ;
+
+argDecls : ARG varDefList SEMICOLON
+         | ARG varDefList? ELLIPSES NAME SEMICOLON
+         | PIPE pipeDefList PIPE
+         | PIPE pipeDefList? ELLIPSES NAME PIPE
+         ;
+
+varDefList : varDef (COMMA varDef)* ;
+
+varDef : NAME
+       | NAME EQUALS expr
+       | NAME PAREN_OPEN exprSeq PAREN_CLOSE
+       ;
+
+expr : expr1
+     | indexSeriesAssign
+     | CLASSNAME
+     | expr binopKey adverb? expr
+     | NAME EQUALS expr
+     | TILDE  NAME EQUALS expr
+     | expr DOT NAME EQUALS expr
+     | NAME PAREN_OPEN argList keyArgList? PAREN_CLOSE EQUALS expr
+     | HASH multiAssignVars EQUALS expr
+     | expr1 SQUARE_OPEN argList SQUARE_CLOSE EQUALS expr
+     ;
+
+expr1 : literal
+      | block
+      | listComp
+      | NAME
+      | UNDERSCORE
+      | message
+      | PAREN_OPEN exprSeq PAREN_CLOSE
+      | TILDE NAME
+      | SQUARE_OPEN arrayElems SQUARE_CLOSE
+      | PAREN_OPEN numericSeries PAREN_CLOSE
+      | PAREN_OPEN COLON numericSeries PAREN_CLOSE
+      | PAREN_OPEN dictLiterals? PAREN_CLOSE
+      | expr1 SQUARE_OPEN argList SQUARE_CLOSE
+      | indexSeries
+      ;
+
+block : HASH? CURLY_OPEN argDecls? varDecls? body? CURLY_CLOSE ;
+
+body : return?
+     | exprSeq return?
+     ;
+
+return : CARET expr SEMICOLON? ;
+
+exprSeq : expr (SEMICOLON expr)* SEMICOLON? ;
+
+varDecls    : (VAR varDefList SEMICOLON)*? ;
+
+listComp : CURLY_OPEN COLON exprSeq COMMA qualifiers CURLY_CLOSE
+         | CURLY_OPEN SEMICOLON exprSeq COMMA qualifiers CURLY_CLOSE
+         ;
+
+qualifiers : qualifier (COMMA qualifier)* ;
+
+qualifier : NAME ARROW_LEFT exprSeq
+          | NAME NAME ARROW_LEFT exprSeq
+          | exprSeq
+          | VAR NAME EQUALS exprSeq
+          | COLON COLON exprSeq
+          | COLON WHILE exprSeq
+          ;
+
+message : NAME block+
+        | PAREN_OPEN binopKey PAREN_CLOSE block+
+        | NAME PAREN_OPEN PAREN_CLOSE block+
+        | NAME PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
+        | PAREN_OPEN binopKey PAREN_CLOSE PAREN_OPEN PAREN_CLOSE block+
+        | PAREN_OPEN binopKey PAREN_CLOSE PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
+        | NAME PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
+        | PAREN_OPEN binopKey PAREN_CLOSE PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
+        | CLASSNAME SQUARE_OPEN arrayElems? SQUARE_CLOSE
+        | CLASSNAME block+
+        | CLASSNAME PAREN_OPEN PAREN_CLOSE block*
+        | CLASSNAME PAREN_OPEN keyArgList COMMA? PAREN_CLOSE block*
+        | CLASSNAME PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
+        | CLASSNAME PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
+        | expr DOT PAREN_OPEN PAREN_CLOSE block*
+        | expr DOT PAREN_OPEN keyArgList? COMMA? PAREN_CLOSE block*
+        | expr DOT NAME PAREN_OPEN keyArgList COMMA? PAREN_CLOSE block*
+        | expr DOT PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
+        | expr DOT PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
+        | expr DOT NAME PAREN_OPEN PAREN_CLOSE block*
+        | expr DOT NAME PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
+        | expr DOT NAME PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
+        | expr DOT NAME block*
+        ;
+
+binopKey : BINOP
+         | KEYWORD
+         ;
+
+argList : exprSeq (COMMA exprSeq)* ;
+
+keyArgList : keyArg (COMMA keyArg)* ;
+
+keyArg : KEYWORD exprSeq ;
+
+performArgList : (argList COMMA)? ASTERISK exprSeq ;
+
+arrayElems : arrayElem (COMMA arrayElem)* ;
+
+arrayElem : (exprSeq COLON)? exprSeq
+          | KEYWORD exprSeq
+          ;
+
+numericSeries : exprSeq (COMMA exprSeq)? DOT_DOT exprSeq?
+              | DOT_DOT exprSeq
+              ;
+
+indexSeries : expr1 SQUARE_OPEN argList DOT_DOT exprSeq? SQUARE_CLOSE
+            | expr1 SQUARE_OPEN DOT_DOT exprSeq SQUARE_CLOSE
+            ;
+
+indexSeriesAssign : indexSeries EQUALS expr;
+
+adverb : DOT NAME
+       | DOT integer
+       | DOT PAREN_OPEN exprSeq PAREN_CLOSE
+       ;
+
+multiAssignVars : NAME (COMMA NAME)* (ELLIPSES NAME)? ;
+
+pipeDefList : pipeDef (COMMA pipeDef)* ;
+
+pipeDef : NAME EQUALS? literal?
+        | NAME EQUALS? PAREN_OPEN exprSeq PAREN_CLOSE
+        ;
+
+primitive : PRIMITIVE SEMICOLON? ;
+
+classExtension  : PLUS CLASSNAME CURLY_OPEN method* CURLY_CLOSE
+                ;
+
+interpreterCode : PAREN_OPEN varDecls+ body PAREN_CLOSE
+                | varDecls+ body
+                | body
+                ;


### PR DESCRIPTION
Checking in the first iteration of the SClang grammar that ANTLR accepts. I haven't tested it against any sclang code yet, and it has a few known issues:

a) ANTLR requires any left-recursive rules to be directly left-recursive, which has forced the re-ordering of some of the terms between `expr`, `expr1`, and `message`.

b) I haven't yet labeled any of the rule alternatives (`#` syntax ) for a better parsing API, likely many will need it

c) Rule precedence is different from Bison and ANTLR. This may create subtle parsing bugs and requires careful thought around parser validation.