### PR TITLE
Fix parser bugs found by parsing SuperCollider sclang code

### DIFF
--- a/demo/print_tree.cpp
+++ b/demo/print_tree.cpp
@@ -12,28 +12,28 @@ int main(int argc, const char* argv[]) {
       return -1;
     }
 
+    std::string filename(argv[1]);
+
     antlr4::ANTLRFileStream input;
-    input.loadFromFile(std::string(argv[1]));
+    input.loadFromFile(filename);
 
     sprklr::SCLexer lexer(&input);
     antlr4::CommonTokenStream tokens(&lexer);
     tokens.fill();
 
-
-    tokens.fill();
-    for (auto token : tokens.getTokens()) {
-      std::cout << token->toString() << std::endl;
-    }
-
     sprklr::SCParser parser(&tokens);
     antlr4::tree::ParseTree *tree = parser.root();
 
     if (parser.getNumberOfSyntaxErrors()) {
-        std::cerr << "got " << parser.getNumberOfSyntaxErrors() << " syntax errors.\n";
-//        return -1;
+        for (auto token : tokens.getTokens()) {
+            std::cout << token->toString() << std::endl;
+        }
+
+        std::cerr << filename << " got " << parser.getNumberOfSyntaxErrors() << " syntax errors.\n\n";
+        return -1;
     }
-
+/*
     std::cout << tree->toStringTree(&parser) << std::endl;
-
+*/
     return 0;
 }

--- a/demo/print_tree.cpp
+++ b/demo/print_tree.cpp
@@ -25,10 +25,11 @@ int main(int argc, const char* argv[]) {
     antlr4::tree::ParseTree *tree = parser.root();
 
     if (parser.getNumberOfSyntaxErrors()) {
+/*
         for (auto token : tokens.getTokens()) {
             std::cout << token->toString() << std::endl;
         }
-
+*/
         std::cerr << filename << " got " << parser.getNumberOfSyntaxErrors() << " syntax errors.\n\n";
         return -1;
     }

--- a/demo/print_tree.cpp
+++ b/demo/print_tree.cpp
@@ -19,12 +19,18 @@ int main(int argc, const char* argv[]) {
     antlr4::CommonTokenStream tokens(&lexer);
     tokens.fill();
 
+
+    tokens.fill();
+    for (auto token : tokens.getTokens()) {
+      std::cout << token->toString() << std::endl;
+    }
+
     sprklr::SCParser parser(&tokens);
     antlr4::tree::ParseTree *tree = parser.root();
 
     if (parser.getNumberOfSyntaxErrors()) {
         std::cerr << "got " << parser.getNumberOfSyntaxErrors() << " syntax errors.\n";
-        return -1;
+//        return -1;
     }
 
     std::cout << tree->toStringTree(&parser) << std::endl;

--- a/demo/print_tree.cpp
+++ b/demo/print_tree.cpp
@@ -25,16 +25,13 @@ int main(int argc, const char* argv[]) {
     antlr4::tree::ParseTree *tree = parser.root();
 
     if (parser.getNumberOfSyntaxErrors()) {
-/*
         for (auto token : tokens.getTokens()) {
             std::cout << token->toString() << std::endl;
         }
-*/
         std::cerr << filename << " got " << parser.getNumberOfSyntaxErrors() << " syntax errors.\n\n";
         return -1;
     }
-/*
+
     std::cout << tree->toStringTree(&parser) << std::endl;
-*/
     return 0;
 }

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -65,6 +65,7 @@ COLON : ':' ;
 COMMA : ',' ;
 CURLY_OPEN : '{' ;
 CURLY_CLOSE : '}' ;
+GRAVE : '`' ;
 HASH : '#' ;
 TILDE : '~' ;
 PAREN_OPEN : '(' ;

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -9,21 +9,25 @@ CONST : 'const' ;
 INF : 'inf' ;
 PI : 'pi' ;
 VAR : 'var' ;
+
+// Not a reserved word, but still needs to be defined before NAME
 WHILE : 'while' ;
+
+CHARACTER : '$' (.|'\\'.) ;
 
 CLASSNAME : [A-Z] [a-zA-Z0-9_]* ;
 
-FLOAT : [-]? [0-9]+ '.' [0-9]+ ;
+FLOAT : [0-9]+ '.' [0-9]+ ;
 FLOAT_FLAT : [0-9]+ 'b'+ ;
 FLOAT_FLAT_CENTS : [0-9]+ 'b' [0-9]+ ;
-FLOAT_RADIX : [-]? [1-9] [0-9]* 'r' [a-zA-Z0-9]+ '.' [A-Z0-9]+ ;
-FLOAT_SCI : [-]? [0-9]+ ('.' [0-9]+)? 'e' ('-' | '+')? [0-9]+ ;
+FLOAT_RADIX : [1-9] [0-9]* 'r' [a-zA-Z0-9]+ '.' [A-Z0-9]+ ;
+FLOAT_SCI : [0-9]+ ('.' [0-9]+)? 'e' ('-' | '+')? [0-9]+ ;
 FLOAT_SHARP : [0-9]+ 's'+ ;
 FLOAT_SHARP_CENTS : [0-9]+ 's' [0-9]+ ;
 
-INT : [-]? [0-9]+ ;
-INT_HEX : [-]? '0x' [0-9a-f]* ;
-INT_RADIX : [-]? [1-9] [0-9]* 'r' [a-zA-Z0-9]+ ;
+INT : [0-9]+ ;
+INT_HEX : '0x' [0-9a-f]* ;
+INT_RADIX : [1-9] [0-9]* 'r' [a-zA-Z0-9]+ ;
 
 KEYWORD : [a-z] [a-zA-Z0-9_]* ':' ;
 

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -1,37 +1,17 @@
 lexer grammar SCLexer;
 
+// Lexer rules are in priority order, so need to define more specific tokens before more general ones.
+
+// Reserved words
 ARG : 'arg' ;
-
-ARROW_LEFT : '<-' ;
-
-ASTERISK : '*' ;
-
-BINOP : ('!' | '@' | '%' | '&' | '*' | '-' | '+' | '=' | '|' | '<' | '>' | '?' | '/')+ ;
-
-CARET : '^' ;
+CLASSVAR : 'classvar' ;
+CONST : 'const' ;
+INF : 'inf' ;
+PI : 'pi' ;
+VAR : 'var' ;
+WHILE : 'while' ;
 
 CLASSNAME : [A-Z] [a-zA-Z0-9_]* ;
-
-CLASSVAR : 'classvar' ;
-
-COLON : ':' ;
-
-COMMA : ',' ;
-
-COMMENT_LINE : '//' .*? '\n' -> channel(2) ;
-COMMENT_BLOCK : '/*' -> channel(2), pushMode(INSIDE_BLOCK) ;
-
-CONST : 'const' ;
-
-CURLY_OPEN : '{' ;
-CURLY_CLOSE : '}' ;
-
-DOT : '.' ;
-DOT_DOT : '..' ;
-
-ELLIPSES : '...' ;
-
-EQUALS : '=' ;
 
 FLOAT : [-]? [0-9]+ '.' [0-9]+ ;
 FLOAT_FLAT : [0-9]+ 'b'+ ;
@@ -41,56 +21,57 @@ FLOAT_SCI : [-]? [0-9]+ ('.' [0-9]+)? 'e' ('-' | '+')? [0-9]+ ;
 FLOAT_SHARP : [0-9]+ 's'+ ;
 FLOAT_SHARP_CENTS : [0-9]+ 's' [0-9]+ ;
 
-GREATER_THAN : '>' ;
-
-HASH : '#' ;
-
-INF : 'inf' ;
-
 INT : [-]? [0-9]+ ;
 INT_HEX : [-]? '0x' [0-9a-f]* ;
 INT_RADIX : [-]? [1-9] [0-9]* 'r' [a-zA-Z0-9]+ ;
 
 KEYWORD : [a-z] [a-zA-Z0-9_]* ':' ;
 
-LESS_THAN : '<' ;
-
-MINUS : '-' ;
-
 NAME : [a-z] [a-zA-Z0-9_]* ;
-
-PAREN_OPEN : '(' ;
-PAREN_CLOSE : ')' ;
-
-PI : 'pi' ;
-
-PIPE : '|' ;
-
-PLUS : '+' ;
 
 PRIMITIVE : '_' [a-zA-Z0-9_]+ ;
 
-READ_WRITE : '<>' ;
-
-SEMICOLON : ';' ;
-
 STRING : '"' (.|'\\"')*? '"' ;
-
-SQUARE_OPEN : '[' ;
-SQUARE_CLOSE : ']' ;
 
 SYMBOL_QUOTE : '\'' (.|'\\\'')*? ;
 SYMBOL_SLASH : '\\' [a-zA-Z0-9_]* ;
 
+// Comments (not to be confused with binops)
+COMMENT_LINE : '//' .*? '\n' -> channel(2) ;
+COMMENT_BLOCK : '/*' -> channel(2), pushMode(INSIDE_BLOCK) ;
+
+// Valid binop constructions that also happen to be used in the language, so their definition comes before BINOP.
+ARROW_LEFT : '<-' ;
+ASTERISK : '*' ;
+EQUALS : '=' ;
+GREATER_THAN : '>' ;
+LESS_THAN : '<' ;
+MINUS : '-' ;
+PIPE : '|' ;
+PLUS : '+' ;
+READ_WRITE : '<>' ;
+BINOP : ('!' | '@' | '%' | '&' | '*' | '-' | '+' | '=' | '|' | '<' | '>' | '?' | '/')+ ;
+
+// Delimiters.
+CARET : '^' ;
+COLON : ':' ;
+COMMA : ',' ;
+CURLY_OPEN : '{' ;
+CURLY_CLOSE : '}' ;
+HASH : '#' ;
 TILDE : '~' ;
-
+PAREN_OPEN : '(' ;
+PAREN_CLOSE : ')' ;
+SQUARE_OPEN : '[' ;
+SQUARE_CLOSE : ']' ;
 UNDERSCORE : '_' ;
+SEMICOLON : ';' ;
 
-VAR : 'var' ;
+DOT : '.' ;
+DOT_DOT : '..' ;
+ELLIPSES : '...' ;
 
 WHITESPACE : [ \t\r\n]+ -> channel(HIDDEN) ;
-
-WHILE : 'while' ;
 
 mode INSIDE_BLOCK;
 END_BLOCK : '*/' -> channel(2), popMode ;

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -2,13 +2,13 @@ lexer grammar SCLexer;
 
 // Lexer rules are in priority order, so need to define more specific tokens before more general ones.
 
-STRING : '"' (~'"'|'\\' .)* '"' ;
+STRING : '"' (~["\\] |'\\' .)* '"' ;
 
-SYMBOL_QUOTE : '\'' (~'\''|'\\' .)* '\'' ;
+SYMBOL_QUOTE : '\'' (~['\\]|'\\' .)* '\'' ;
 SYMBOL_SLASH : '\\' [a-zA-Z0-9_]* ;
 
 // Comments (not to be confused with binops)
-COMMENT_LINE : '//' ~('\n'|'\r')*? ('\n'|'\r') -> channel(2) ;
+COMMENT_LINE : '//' ~('\n'|'\r')*? ('\n'|'\r'|EOF) -> channel(2) ;
 COMMENT_BLOCK : '/*' (COMMENT_BLOCK|.)*? '*/' -> channel(2) ;
 
 // Reserved words
@@ -17,6 +17,7 @@ CLASSVAR : 'classvar' ;
 CONST : 'const' ;
 FALSE : 'false' ;
 INF : 'inf' ;
+NIL : 'nil' ;
 PI : 'pi' ;
 TRUE : 'true' ;
 VAR : 'var' ;
@@ -37,10 +38,10 @@ FLOAT_SHARP : [0-9]+ 's'+ ;
 FLOAT_SHARP_CENTS : [0-9]+ 's' [0-9]+ ;
 
 INT : [0-9]+ ;
-INT_HEX : '0x' [0-9a-f]* ;
+INT_HEX : '0x' [0-9a-fA-F]* ;
 INT_RADIX : [1-9] [0-9]* 'r' [a-zA-Z0-9]+ ;
 
-KEYWORD : [a-z] [a-zA-Z0-9_]* ':' ;
+KEYWORD : [a-zA-Z0-9_]+ ':' ;
 
 NAME : [a-z] [a-zA-Z0-9_]* ;
 

--- a/grammar/SCLexer.g4
+++ b/grammar/SCLexer.g4
@@ -2,12 +2,23 @@ lexer grammar SCLexer;
 
 // Lexer rules are in priority order, so need to define more specific tokens before more general ones.
 
+STRING : '"' (~'"'|'\\' .)* '"' ;
+
+SYMBOL_QUOTE : '\'' (~'\''|'\\' .)* '\'' ;
+SYMBOL_SLASH : '\\' [a-zA-Z0-9_]* ;
+
+// Comments (not to be confused with binops)
+COMMENT_LINE : '//' ~('\n'|'\r')*? ('\n'|'\r') -> channel(2) ;
+COMMENT_BLOCK : '/*' (COMMENT_BLOCK|.)*? '*/' -> channel(2) ;
+
 // Reserved words
 ARG : 'arg' ;
 CLASSVAR : 'classvar' ;
 CONST : 'const' ;
+FALSE : 'false' ;
 INF : 'inf' ;
 PI : 'pi' ;
+TRUE : 'true' ;
 VAR : 'var' ;
 
 // Not a reserved word, but still needs to be defined before NAME
@@ -34,15 +45,6 @@ KEYWORD : [a-z] [a-zA-Z0-9_]* ':' ;
 NAME : [a-z] [a-zA-Z0-9_]* ;
 
 PRIMITIVE : '_' [a-zA-Z0-9_]+ ;
-
-STRING : '"' (.|'\\"')*? '"' ;
-
-SYMBOL_QUOTE : '\'' (.|'\\\'')*? ;
-SYMBOL_SLASH : '\\' [a-zA-Z0-9_]* ;
-
-// Comments (not to be confused with binops)
-COMMENT_LINE : '//' .*? '\n' -> channel(2) ;
-COMMENT_BLOCK : '/*' -> channel(2), pushMode(INSIDE_BLOCK) ;
 
 // Valid binop constructions that also happen to be used in the language, so their definition comes before BINOP.
 ARROW_LEFT : '<-' ;
@@ -76,8 +78,3 @@ DOT_DOT : '..' ;
 ELLIPSES : '...' ;
 
 WHITESPACE : [ \t\r\n]+ -> channel(HIDDEN) ;
-
-mode INSIDE_BLOCK;
-END_BLOCK : '*/' -> channel(2), popMode ;
-IGNORE : . -> more ;
-NEST_BLOCK : '/*' -> channel(2), pushMode(INSIDE_BLOCK) ;

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -105,7 +105,7 @@ rSlotDef   : LESS_THAN? name
 method : ASTERISK? methodName CURLY_OPEN argDecls? varDecls? primitive? body? CURLY_CLOSE ;
 
 methodName : name
-           | BINOP
+           | binop
            ;
 
 argDecls : ARG varDefList SEMICOLON
@@ -125,7 +125,7 @@ expr : expr1
      | CLASSNAME
      | expr binopKey adverb? expr
      | name EQUALS expr
-     | TILDE  name EQUALS expr
+     | TILDE name EQUALS expr
      | expr DOT name EQUALS expr
      | name PAREN_OPEN argList keyArgList? PAREN_CLOSE EQUALS expr
      | HASH multiAssignVars EQUALS expr
@@ -205,9 +205,21 @@ qualifier : name ARROW_LEFT exprSeq
           | COLON WHILE exprSeq
           ;
 
-binopKey : BINOP
+binopKey : binop
          | KEYWORD
          ;
+
+binop : ARROW_LEFT
+      | ASTERISK
+      | EQUALS
+      | GREATER_THAN
+      | LESS_THAN
+      | MINUS
+      | PIPE
+      | PLUS
+      | READ_WRITE
+      | BINOP
+      ;
 
 argList : exprSeq (COMMA exprSeq)* ;
 

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -36,13 +36,14 @@ name : NAME
      ;
 
 literal : coreLiteral
-        | listLiteral
+        | list
         ;
 
 coreLiteral : integer
             | floatingPoint
             | strings
             | symbol
+            | booleanConstant
             | CHARACTER
             ;
 
@@ -85,21 +86,27 @@ symbol : SYMBOL_QUOTE
        | SYMBOL_SLASH
        ;
 
+booleanConstant : TRUE
+                | FALSE
+                ;
+
+list : HASH innerListLiteral ;
+
+innerListLiteral : SQUARE_OPEN listLiterals? SQUARE_CLOSE
+                 | CLASSNAME SQUARE_OPEN listLiterals? SQUARE_CLOSE
+                 ;
+
 listLiteral : coreLiteral
             | innerListLiteral
             | innerDictLiteral
             | name
             ;
 
-innerListLiteral : SQUARE_OPEN listLiterals? SQUARE_CLOSE
-                 | CLASSNAME SQUARE_OPEN listLiterals? SQUARE_CLOSE
-                 ;
-
 listLiterals : listLiteral (COMMA listLiteral)* ;
 
 innerDictLiteral : PAREN_OPEN dictLiterals? PAREN_CLOSE ;
 
-dictLiterals : dictLiteral (COMMA dictLiteral)* ;
+dictLiterals : dictLiteral (COMMA dictLiteral)* COMMA? ;
 
 dictLiteral : listLiteral COLON listLiteral
             | KEYWORD listLiteral
@@ -137,7 +144,7 @@ expr : literal
      | UNDERSCORE
      | PAREN_OPEN exprSeq PAREN_CLOSE
      | TILDE name
-     | SQUARE_OPEN arrayElems SQUARE_CLOSE
+     | SQUARE_OPEN arrayElems? SQUARE_CLOSE
      | PAREN_OPEN numericSeries PAREN_CLOSE
      | PAREN_OPEN COLON numericSeries PAREN_CLOSE
      | PAREN_OPEN dictLiterals? PAREN_CLOSE
@@ -168,12 +175,12 @@ expr : literal
      | CLASSNAME SQUARE_OPEN arrayElems? SQUARE_CLOSE
      | CLASSNAME block+
      | CLASSNAME PAREN_OPEN PAREN_CLOSE block*
-     | CLASSNAME PAREN_OPEN keyArgList COMMA? PAREN_CLOSE block*
+     | CLASSNAME PAREN_OPEN keyArgList PAREN_CLOSE block*
      | CLASSNAME PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
      | CLASSNAME PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
      | expr DOT PAREN_OPEN PAREN_CLOSE block*
-     | expr DOT PAREN_OPEN keyArgList? COMMA? PAREN_CLOSE block*
-     | expr DOT name PAREN_OPEN keyArgList COMMA? PAREN_CLOSE block*
+     | expr DOT PAREN_OPEN keyArgList? PAREN_CLOSE block*
+     | expr DOT name PAREN_OPEN keyArgList PAREN_CLOSE block*
      | expr DOT PAREN_OPEN argList keyArgList? PAREN_CLOSE block*
      | expr DOT PAREN_OPEN performArgList keyArgList? PAREN_CLOSE
      | expr DOT name PAREN_OPEN PAREN_CLOSE block*
@@ -190,7 +197,7 @@ body : returnExpr
 
 returnExpr : CARET expr SEMICOLON? ;
 
-exprSeq : expr (SEMICOLON expr)* SEMICOLON? ;
+exprSeq : expr (SEMICOLON expr)*? SEMICOLON? ;
 
 varDecls : (VAR varDefList SEMICOLON)+ ;
 
@@ -224,17 +231,18 @@ binop : ARROW_LEFT
       | BINOP
       ;
 
-argList : exprSeq (COMMA exprSeq)* ;
+argList : exprSeq (COMMA exprSeq)* COMMA? ;
 
-keyArgList : keyArg (COMMA keyArg)* ;
+keyArgList : keyArg (COMMA keyArg)* COMMA? ;
 
 keyArg : KEYWORD exprSeq ;
 
 performArgList : (argList COMMA)? ASTERISK exprSeq ;
 
-arrayElems : arrayElem (COMMA arrayElem)* ;
+arrayElems : arrayElem (COMMA arrayElem)*? COMMA? ;
 
-arrayElem : (exprSeq COLON)? exprSeq
+arrayElem : exprSeq
+          | exprSeq COLON exprSeq
           | KEYWORD exprSeq
           ;
 

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -145,6 +145,7 @@ expr : literal
      | UNDERSCORE
      | PAREN_OPEN exprSeq PAREN_CLOSE
      | TILDE name
+     | GRAVE expr
      | SQUARE_OPEN arrayElems? SQUARE_CLOSE
      | PAREN_OPEN numericSeries PAREN_CLOSE
      | PAREN_OPEN COLON numericSeries PAREN_CLOSE

--- a/grammar/SCParser.g4
+++ b/grammar/SCParser.g4
@@ -45,6 +45,7 @@ coreLiteral : integer
             | symbol
             | booleanConstant
             | CHARACTER
+            | NIL
             ;
 
 integer : integerNumber
@@ -147,7 +148,7 @@ expr : literal
      | SQUARE_OPEN arrayElems? SQUARE_CLOSE
      | PAREN_OPEN numericSeries PAREN_CLOSE
      | PAREN_OPEN COLON numericSeries PAREN_CLOSE
-     | PAREN_OPEN dictLiterals? PAREN_CLOSE
+     | PAREN_OPEN dictElements? PAREN_CLOSE
      | expr SQUARE_OPEN argList SQUARE_CLOSE
      | expr SQUARE_OPEN argList SQUARE_CLOSE EQUALS expr
         // IndexSeries
@@ -250,6 +251,12 @@ numericSeries : exprSeq (COMMA exprSeq)? DOT_DOT exprSeq?
               | DOT_DOT exprSeq
               ;
 
+dictElements : dictElement (COMMA dictElement)* COMMA? ;
+
+dictElement : exprSeq COLON exprSeq
+            | KEYWORD exprSeq
+            ;
+
 adverb : DOT name
        | DOT integer
        | DOT PAREN_OPEN exprSeq PAREN_CLOSE
@@ -257,7 +264,7 @@ adverb : DOT name
 
 multiAssignVars : name (COMMA name)* (ELLIPSES name)? ;
 
-pipeDefList : pipeDef (COMMA pipeDef)* ;
+pipeDefList : pipeDef (COMMA? pipeDef)* ;
 
 pipeDef : name EQUALS? literal?
         | name EQUALS? PAREN_OPEN exprSeq PAREN_CLOSE


### PR DESCRIPTION
Fixes all the parser bugs I could find by running the print_tree demo application on all of the `.sc` and `.scd` files in the supercollider repository.