### PR TITLE
Bundle antlr4 static lib with exported C++ parser

### DIFF
--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,5 +1,2 @@
-
-# add generated grammar to demo binary target
 add_executable(print_tree print_tree.cpp)
-target_include_directories(print_tree PRIVATE ${ANTLR4_INCLUDE_DIRS})
-target_link_libraries(print_tree antlr4_static sprklr)
+target_link_libraries(print_tree sprklr)

--- a/grammar/CMakeLists.txt
+++ b/grammar/CMakeLists.txt
@@ -9,12 +9,16 @@ antlr_target(SCParser SCParser.g4 PARSER
              DEPENDS_ANTLR SCLexer
              COMPILE_FLAGS -lib ${ANTLR_SCLexer_OUTPUT_DIR})
 
-# add antrl4cpp artifacts to project environment
-include_directories(${ANTLR4_INCLUDE_DIRS})
-
 add_library(sprklr STATIC
             ${ANTLR_SCLexer_CXX_OUTPUTS}
             ${ANTLR_SCParser_CXX_OUTPUTS})
 
-target_include_directories(sprklr PUBLIC ${ANTLR_SCLexer_OUTPUT_DIR})
-target_include_directories(sprklr PUBLIC ${ANTLR_SCParser_OUTPUT_DIR})
+target_include_directories(sprklr PUBLIC
+    ${ANTLR4_INCLUDE_DIRS}
+    ${ANTLR_SCLexer_OUTPUT_DIR}
+    ${ANTLR_SCParser_OUTPUT_DIR}
+)
+
+target_link_libraries(sprklr
+    antlr4_static
+)


### PR DESCRIPTION
Some build fixes that make using the parser library convenient from Hadron. If a user wants multiple ANTLR parsers, this won't work as well but for the single ANLTR-based parser library use case this makes life easier. In that case, I could create a second target that doesn't export antlr, allowing users to bring their own ANTLR lib.